### PR TITLE
ImageMagick Support

### DIFF
--- a/export.py
+++ b/export.py
@@ -67,6 +67,9 @@ class ExportThread:
         elif self.renderer == 'rendersvg':
             cmd = ['rendersvg', '-w', str(size), '-h', str(size),
                     os.path.abspath(tmp_name), os.path.abspath(path)]
+        elif self.renderer == 'imagemagick':
+            cmd = ['convert', '-background', 'none', '-density', str(size / 32 * 128),
+                   '-resize', str(size) + 'x' + str(size), os.path.abspath(tmp_name), os.path.abspath(path)]
         else:
             raise AssertionError
         try:

--- a/orxport.py
+++ b/orxport.py
@@ -101,7 +101,7 @@ def main():
         print(HELP)
         sys.exit(2)
     try:
-        if renderer not in ['inkscape', 'rendersvg']:
+        if renderer not in ['inkscape', 'rendersvg', 'imagemagick']:
             raise Exception('Invalid renderer: ' + renderer)
         log.out(f'Loading manifest file...', 36)
         m = manifest.Manifest(os.path.dirname(manifest_path),


### PR DESCRIPTION
This PR adds ImageMagick as an optional PNG renderer. Run orxporter with `-r imagemagick` to use.

Example output:
![1f9d1-10162c-200d-1f4bb](https://user-images.githubusercontent.com/202160/49480475-bf7abf00-f81e-11e8-95f2-2b71c4934a0f.png) ![1f9d1-10162c-200d-1f3a4](https://user-images.githubusercontent.com/202160/49480484-c4d80980-f81e-11e8-9683-58943436c4a1.png) ![1f9d1-10162c-200d-1f962](https://user-images.githubusercontent.com/202160/49480487-c73a6380-f81e-11e8-9bf2-7417efe0118e.png)
