### PR TITLE
Added FLIF and WebP export formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Prerequisites
 * [rendersvg](https://github.com/RazrFalcon/resvg/tree/master/tools/rendersvg)
   (optional; for rasterisation)
 * exiftool (optional; for embedding licensing metadata)
+* [FLIF reference encoder/decoder](https://github.com/FLIF-hub/FLIF) (optional; for FLIF output)
+* [libwebp](https://developers.google.com/speed/webp/docs/precompiled) (optional; for WebP output)
 
 Usage
 -----

--- a/orxport.py
+++ b/orxport.py
@@ -46,6 +46,8 @@ OPTIONS:
 OUTPUT FORMATS:
 svg
 png-SIZE
+flif-SIZE
+webp-SIZE
 
 RENDERERS:
 ''' + '\n'.join(RENDERERS)


### PR DESCRIPTION
Mutant Standard can now output to FLIF and WebP formats, using similar format parameters as PNG.

Both export formats render temporary PNGs, regardless of whether PNGs have already been exported beforehand or not. As per our conversations, there will eventuallly need to be some kind of dependency tree system to prevent redundant temporary file generation, especially when fonts come around (as both sbix and CBx formats use PNG data as well).

There's also copypaste code involved here.
