### PR TITLE
Add an export cache system

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -1,0 +1,172 @@
+import collections
+import hashlib
+import os
+import shutil
+
+import svg
+import util
+
+
+class Cache:
+    """
+    Implements a cache system for emoji.
+
+    This cache is implemented based on a cache directory where files are placed
+    in directories by the format they were exported to; the individual cache
+    files are named by their key, which is generated from:
+      - the source file of the emoji;
+      - the colour modifiers applied to the emoji;
+
+    This defines how the emoji looks, and makes it such that a change in either
+    the source or the manifest palette will not reuse the file in cache.
+    """
+
+    cache_dir = None
+
+    def __init__(self, cache_dir):
+        """
+        Initiate an export cache instance. Requires a directory path (which may
+        or may not exist already) to function.
+        """
+        if not isinstance(cache_dir, str):
+            raise ValueError("Cache dir must be a string path")
+
+        self.cache_dir = cache_dir
+        self.initiate_cache_dir()
+
+    def initiate_cache_dir(self):
+        """Make the cache directory if it does not exist already."""
+        if not os.path.exists(self.cache_dir):
+            try:
+                os.mkdir(self.cache_dir)
+            except OSError as exc:
+                raise RuntimeError("Cannot create cache directory "
+                                   "'{}'".format(self.cache_dir)) from exc
+        elif not os.path.isdir(self.cache_dir):
+            raise RuntimeError("Cache path '{}' exists but is not a "
+                               "directory".format(self.cache_dir))
+
+        return True
+
+    @staticmethod
+    def get_cache_key(emoji, manifest, emoji_src):
+        """
+        Get the cache key for a given emoji.
+
+        This needs to take into account multiple parts:
+            - SVG source file: Allows tracking changes to the source
+            - Colour modifiers, if applicable: Tracks changes in the manifest
+        """
+        if 'cache_key' in emoji:
+            return emoji['cache_key']
+
+        src = emoji_src
+        if isinstance(src, collections.abc.ByteString):
+            src = bytes(src, 'utf-8')
+        src_hash = hashlib.sha256(bytes(emoji_src, 'utf-8')).digest()
+
+        # Find which variable colours are in this emoji
+        colors = None
+        if 'color' in emoji:
+            pal_src, pal_dst = util.get_color_palettes(emoji, manifest)
+            colors = []
+
+            changed = svg.translated_colors(emoji_src, pal_src, pal_dst)
+            colors = sorted(changed.items())
+
+        # Collect the parts
+        key_parts = (
+            ('src_hash', src_hash),
+            ('colors', colors),
+        )
+
+        # Calculate a unique hash from the parts, building the data to feed
+        # to the algorithm from the repr() encoded as UTF-8.
+        # This should be stable as long as the inputs are the same, as we're
+        # using data structures with an order guarantee.
+        raw_key = bytes(repr(key_parts), 'utf-8')
+        key = hashlib.sha256(raw_key).hexdigest()
+
+        return key
+
+    def build_emoji_cache_path(self, emoji, f):
+        """
+        Build the full path to the cache emoji file (regardless of presence).
+        This requires the 'cache_key' field of the emoji object that is passed
+        to be present.
+        """
+        if 'cache_key' not in emoji:
+            raise RuntimeError("Emoji '{}' does not have a cache key "
+                               "set!".format(emoji['short']))
+        dir_path = self.build_cache_dir_by_format(f)
+        return os.path.join(dir_path, emoji['cache_key'])
+
+    def build_cache_dir_by_format(self, f):
+        """
+        Checks if the build cache directory for the given format exists,
+        attempting to create it if it doesn't, and returns its path.
+        """
+        if not self.cache_dir:
+            raise RuntimeError("cache dir not set")
+
+        dir_path = os.path.join(self.cache_dir, f)
+        if os.path.isdir(dir_path):
+            # Return immediately if it exists
+            return dir_path
+
+        if os.path.exists(dir_path):  # Exists but is not directory
+            raise RuntimeError("cache path '{}' exists, but it is not a "
+                               "directory".format(dir_path))
+
+        # Create directory
+        try:
+            os.mkdir(dir_path)
+        except OSError as exc:
+            raise RuntimeError("Cannot create build cache directory "
+                               "'{}'".format(dir_path)) from exc
+
+        return dir_path
+
+    def get_cache(self, emoji, f):
+        """
+        Get the path to an existing emoji in a given format f that is in cache.
+        """
+        cache_file = self.build_emoji_cache_path(emoji, f)
+        if os.path.exists(cache_file):
+            return cache_file
+
+        return False
+
+    def save_to_cache(self, emoji, f, export_path):
+        """Copy an exported path to the cache directory."""
+        if not os.path.exists(export_path):
+            raise RuntimeError("Could not find exported emoji '{}' at "
+                               "'{}'".format(emoji['short'], export_path))
+
+        cache_file = self.build_emoji_cache_path(emoji, f)
+
+        try:
+            shutil.copy(export_path, cache_file)
+        except OSError as exc:
+            raise RuntimeError("Unable to save '{}' to cache ('{}'): "
+                               "{}.".format(emoji['short'], cache_file,
+                                            str(exc)))
+
+        return True
+
+    def load_from_cache(self, emoji, f, export_path):
+        """Copy an emoji from cache to its final path."""
+        if not self.cache_dir:
+            return False
+
+        cache_file = self.get_cache(emoji, f)
+        if not cache_file:
+            return False
+
+        try:
+            shutil.copy(cache_file, export_path)
+        except OSError as exc:
+            raise RuntimeError("Unable to retrieve '{}' from cache ('{}'): "
+                               "{}".format(emoji['short'], cache_file,
+                                           str(exc)))
+        return True

--- a/check.py
+++ b/check.py
@@ -85,9 +85,6 @@ def emoji(m, filtered_emoji, input_path, formats, path, src_size,
                 cached_emoji.append(e)
             else:
                 if cached_formats:
-                    # save which formats are in cache for later
-                    # a meta-cache, so to speak
-                    e['cached_formats'] = cached_formats
                     partial_cached_emoji_count += 1
                 exporting_emoji.append(e)
         else:

--- a/check.py
+++ b/check.py
@@ -6,7 +6,7 @@ import svg
 import log
 
 def emoji(m, filtered_emoji, input_path, formats, path, src_size,
-           num_threads, renderer, max_batch, verbose):
+           num_threads, renderer, max_batch, cache, verbose):
     """
     Checks all emoji in a very light validation as well as checking if emoji
     aren't filtered out by user choices.
@@ -29,6 +29,8 @@ def emoji(m, filtered_emoji, input_path, formats, path, src_size,
     """
 
     exporting_emoji = []
+    cached_emoji = []
+    partial_cached_emoji_count = 0
     skipped_emoji_count = 0
 
     for i, e in enumerate(filtered_emoji):
@@ -71,9 +73,29 @@ def emoji(m, filtered_emoji, input_path, formats, path, src_size,
                                     str(img_size[0]) + 'x' + str(img_size[1])
                                     ))
 
-        # add the emoji to exporting_emoji if it's passed all the tests.
-        exporting_emoji.append(e)
+        if cache:
+            # set the cache key in the emoji object for later reference
+            emoji_cache_key = cache.get_cache_key(e, m, emoji_svg)
+            e['cache_key'] = emoji_cache_key
+
+            # check if the emoji is in cache
+            cache_status = {f: cache.get_cache(e, f) for f in formats}
+            cached_formats = [f for (f, p) in cache_status.items() if p]
+            if len(cached_formats) == len(formats):
+                cached_emoji.append(e)
+            else:
+                if cached_formats:
+                    # save which formats are in cache for later
+                    # a meta-cache, so to speak
+                    e['cached_formats'] = cached_formats
+                    partial_cached_emoji_count += 1
+                exporting_emoji.append(e)
+        else:
+            # add the emoji to exporting_emoji if it's passed all the tests.
+            exporting_emoji.append(e)
 
     return { "exporting_emoji" : exporting_emoji
            , "skipped_emoji_count" : skipped_emoji_count
+           , "cached_emoji": cached_emoji
+           , "partial_cached_emoji_count": partial_cached_emoji_count
            }

--- a/dest_paths.py
+++ b/dest_paths.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 import re
 
@@ -86,3 +87,11 @@ def format_path(path, emoji, format):
         res = res.replace(match, repl)
 
     return res
+
+def make_dir_structure_for_file(path):
+    try:
+        dirname = os.path.dirname(path)
+        if dirname:
+            os.makedirs(dirname, exist_ok=True)
+    except IOError:
+        raise Exception('Could not create directory: ' + dirname)

--- a/export.py
+++ b/export.py
@@ -48,6 +48,35 @@ def export(m, filtered_emoji, input_path, formats, path, src_size,
     # --------------------------------------------------------------------------
     # declare some specs of this export.
 
+    export_step(exporting_emoji, num_threads, m, input_path, formats, path,
+                renderer, license_enabled)
+
+
+
+
+    # exif license pass
+    # (currently only just applies to PNGs)
+    # --------------------------------------------------------------------------
+    if ('exif' in m.license) and license_enabled:
+        exif_compatible_images = []
+
+        for e in exporting_emoji:
+            for f in formats:
+                if f.split("-")[0] in ["png", "pngc", "avif"]:
+
+                    try:
+                        exif_compatible_images.append(format_path(path, e, f))
+                    except FilterException:
+                        if verbose:
+                            log.out(f"- Emoji filtered from metadata: {e['short']}", 34)
+                        continue
+
+        if exif_compatible_images:
+            log.out(f'Adding EXIF metadata to all compatible raster files...', 36)
+            image_proc.batch_add_exif_metadata(exif_compatible_images, m.license.get('exif'), max_batch)
+
+
+def export_step(exporting_emoji, num_threads, m, input_path, formats, path, renderer, license_enabled):
     log.out(f"Exporting {len(exporting_emoji)} emoji...", 36)
     log.out(f"- {', '.join(formats)}") # print formats
     log.out(f"- to '{path}'") # print out path
@@ -124,27 +153,3 @@ def export(m, filtered_emoji, input_path, formats, path, src_size,
 
     log.export_task_count = 0
     log.filtered_export_task_count = 0
-
-
-
-
-    # exif license pass
-    # (currently only just applies to PNGs)
-    # --------------------------------------------------------------------------
-    if ('exif' in m.license) and license_enabled:
-        exif_compatible_images = []
-
-        for e in exporting_emoji:
-            for f in formats:
-                if f.split("-")[0] in ["png", "pngc", "avif"]:
-
-                    try:
-                        exif_compatible_images.append(format_path(path, e, f))
-                    except FilterException:
-                        if verbose:
-                            log.out(f"- Emoji filtered from metadata: {e['short']}", 34)
-                        continue
-
-        if exif_compatible_images:
-            log.out(f'Adding EXIF metadata to all compatible raster files...', 36)
-            image_proc.batch_add_exif_metadata(exif_compatible_images, m.license.get('exif'), max_batch)

--- a/export.py
+++ b/export.py
@@ -48,7 +48,7 @@ def export(m, filtered_emoji, input_path, formats, path, src_size,
     # --------------------------------------------------------------------------
     # declare some specs of this export.
 
-    log.out("Exporting emoji...", 36)
+    log.out(f"Exporting {len(exporting_emoji)} emoji...", 36)
     log.out(f"- {', '.join(formats)}") # print formats
     log.out(f"- to '{path}'") # print out path
 

--- a/export.py
+++ b/export.py
@@ -1,3 +1,4 @@
+import itertools
 import os
 import queue
 import time
@@ -6,7 +7,7 @@ import sys
 import check
 from exception import FilterException
 from export_thread import ExportThread
-from dest_paths import format_path
+from dest_paths import format_path, make_dir_structure_for_file
 import image_proc
 import log
 
@@ -16,7 +17,7 @@ import log
 
 
 def export(m, filtered_emoji, input_path, formats, path, src_size,
-           num_threads, renderer, max_batch, verbose, license_enabled):
+           num_threads, renderer, max_batch, verbose, license_enabled, cache):
     """
     Runs the entire orxporter process, includes preliminary checking and
     validation of emoji metadata and running the tasks associated with exporting.
@@ -26,9 +27,11 @@ def export(m, filtered_emoji, input_path, formats, path, src_size,
     # --------------------------------------------------------------------------
     log.out('Checking emoji...', 36)
     check_result = check.emoji(m, filtered_emoji, input_path, formats, path, src_size,
-               num_threads, renderer, max_batch, verbose)
+               num_threads, renderer, max_batch, cache, verbose)
 
     exporting_emoji = check_result["exporting_emoji"]
+    cached_emoji = check_result["cached_emoji"]
+    partial_cached_emoji_count = check_result["partial_cached_emoji_count"]
     skipped_emoji_count = check_result["skipped_emoji_count"]
 
     if skipped_emoji_count > 0:
@@ -36,11 +39,16 @@ def export(m, filtered_emoji, input_path, formats, path, src_size,
 
         if not verbose:
             log.out(f"- use the --verbose flag to see what those emoji are and why they were skipped.", 34)
+    if cached_emoji:
+        log.out(f"- {len(cached_emoji)} emoji will be reused from cache.", 32)
+    if partial_cached_emoji_count:
+        log.out(f"- {partial_cached_emoji_count} emoji will be partially "
+                "reused from cache.", 32)
     log.out('- done!', 32)
 
 
     # If there's no emoji to export, tell the program to quit.
-    if len(exporting_emoji) == 0:
+    if len(exporting_emoji) == 0 and len(cached_emoji) == 0:
         raise SystemExit('>∆∆< It looks like you have no emoji to export!')
 
 
@@ -48,11 +56,24 @@ def export(m, filtered_emoji, input_path, formats, path, src_size,
     # --------------------------------------------------------------------------
     # declare some specs of this export.
 
-    export_step(exporting_emoji, num_threads, m, input_path, formats, path,
-                renderer, license_enabled)
+    if exporting_emoji:
+        export_step(exporting_emoji, num_threads, m, input_path, formats, path,
+                    renderer, license_enabled, cache)
 
 
 
+    # Copy files from cache
+    # --------------------------------------------------------------------------
+    if cached_emoji:
+        log.out(f"Copying {len(cached_emoji)} emoji from cache...", 36)
+
+        for e in cached_emoji:
+            for f in formats:
+                final_path = format_path(path, e, f)
+                make_dir_structure_for_file(final_path)
+                cache.load_from_cache(e, f, final_path)
+
+        log.out(f"- done!", 32)
 
     # exif license pass
     # (currently only just applies to PNGs)
@@ -60,7 +81,7 @@ def export(m, filtered_emoji, input_path, formats, path, src_size,
     if ('exif' in m.license) and license_enabled:
         exif_compatible_images = []
 
-        for e in exporting_emoji:
+        for e in itertools.chain(exporting_emoji, cached_emoji):
             for f in formats:
                 if f.split("-")[0] in ["png", "pngc", "avif"]:
 
@@ -76,7 +97,7 @@ def export(m, filtered_emoji, input_path, formats, path, src_size,
             image_proc.batch_add_exif_metadata(exif_compatible_images, m.license.get('exif'), max_batch)
 
 
-def export_step(exporting_emoji, num_threads, m, input_path, formats, path, renderer, license_enabled):
+def export_step(exporting_emoji, num_threads, m, input_path, formats, path, renderer, license_enabled, cache):
     log.out(f"Exporting {len(exporting_emoji)} emoji...", 36)
     log.out(f"- {', '.join(formats)}") # print formats
     log.out(f"- to '{path}'") # print out path
@@ -98,7 +119,8 @@ def export_step(exporting_emoji, num_threads, m, input_path, formats, path, rend
         threads = []
         for i in range(num_threads):
             threads.append(ExportThread(emoji_queue, str(i), len(exporting_emoji),
-                                        m, input_path, formats, path, renderer, license_enabled))
+                                        m, input_path, formats, path, renderer,
+                                        license_enabled, cache))
 
 
         # keeps checking if the export queue is done.

--- a/export_thread.py
+++ b/export_thread.py
@@ -151,9 +151,11 @@ class ExportThread:
                 # for each format in the emoji, export it as that
                 for f in self.formats:
                     final_path = dest_paths.format_path(self.path, emoji, f)
-                    if self.cache and f in emoji.get('cached_formats', []):
-                        self.cache.load_from_cache(emoji, f, final_path)
-                    else:
+                    cache_hit = False
+                    if self.cache:
+                        cache_hit = self.cache.load_from_cache(emoji, f,
+                                                               final_path)
+                    if not cache_hit:
                         self.export_emoji(emoji, emoji_svg, f, self.path,
                                           self.m.license)
                         if self.cache:

--- a/export_thread.py
+++ b/export_thread.py
@@ -60,12 +60,7 @@ class ExportThread:
         final_path = dest_paths.format_path(path, emoji, f)
 
         # try to make the directory for this particular export batch.
-        try:
-            dirname = os.path.dirname(final_path)
-            if dirname:
-                os.makedirs(dirname, exist_ok=True)
-        except IOError:
-            raise Exception('Could not create directory: ' + dirname)
+        dest_paths.make_dir_structure_for_file(final_path)
 
 
         # svg format doesn't involve a resolution so it can go straight to export.

--- a/export_thread.py
+++ b/export_thread.py
@@ -8,6 +8,7 @@ from exception import FilterException
 import dest_paths
 import export_task
 import svg
+import util
 import log
 
 class ExportThread:
@@ -148,9 +149,7 @@ class ExportThread:
 
                 # convert colormaps (if applicable)
                 if 'color' in emoji:
-                    cmap = self.m.colormaps[emoji['color']]
-                    pfrom = self.m.palettes[cmap['src']]
-                    pto = self.m.palettes[cmap['dst']]
+                    pfrom, pto = util.get_color_palettes(emoji, self.m)
                     emoji_svg = svg.translate_color(emoji_svg, pfrom, pto)
 
                 # for each format in the emoji, export it as that

--- a/orxport.py
+++ b/orxport.py
@@ -261,7 +261,8 @@ def main():
 
             export.export(m, filtered_emoji, input_path, output_formats,
                           os.path.join(output_path, output_naming), src_size,
-                          num_threads, renderer, max_batch, verbose, license_enabled)
+                          num_threads, renderer, max_batch, verbose,
+                          license_enabled, cache)
 
 
 

--- a/orxport.py
+++ b/orxport.py
@@ -11,6 +11,7 @@ import log
 
 import orx.manifest
 import orx.params
+from cache import Cache
 
 VERSION = '0.3.0'
 
@@ -77,6 +78,9 @@ IMAGE BUILD:
 
 -t      Number of threads working on export tasks (default: {DEF_NUM_THREADS})
 
+-C      Cache directory
+        Uses the argument as the directory for the export cache.
+
 
 JSON BUILD:
 ----------------------------------------------------
@@ -118,10 +122,11 @@ def main():
     num_threads = DEF_NUM_THREADS
     force_desc = False
     max_batch = DEF_MAX_BATCH
+    cache = False
     verbose = False
     try:
         opts, _ = getopt.getopt(sys.argv[1:],
-                                'hm:i:o:f:F:ce:j:J:q:t:r:b:p:l',
+                                'hm:i:o:f:F:ce:j:J:q:t:r:b:p:lC:',
                                 ['help', 'force-desc', 'verbose'])
 
 
@@ -153,6 +158,9 @@ def main():
                 num_threads = int(arg)
                 if num_threads <= 0:
                     raise ValueError
+            elif opt == '-C':
+                cache = Cache(cache_dir=arg)
+
 
             # JSON
             elif opt == '-j':

--- a/svg.py
+++ b/svg.py
@@ -4,20 +4,42 @@ def translate_color(svg, pfrom, pto):
     """
     Translates colours from a source file's original colours into new colours.
     """
+    res, _ = _translate_color(svg, pfrom, pto)
+    return res
 
+def translated_colors(svg, pfrom, pto):
+    """
+    Return a dictionary of (entry: to_colour) for the colours that were
+    translated in svg
+    """
+    _, changed = _translate_color(svg, pfrom, pto)
+    return changed
+
+def _translate_color(svg, pfrom, pto):
+    """
+    Translates colours on the svg file from "pfrom" to "pto", reporting also
+    which colours changed.
+    """
     # looks for incidences of one colour, compares it and replaces it.
     res = svg
+    changed = {}
     for centry, ccol in pfrom.items():
         cr = ccol + ';'
         cro = pto.get(centry)
         if not cro:
             continue
         cro += ';'
-        res = re.sub(cr, cro, res, flags=re.IGNORECASE)
+        res, count = re.subn(cr, cro, res, flags=re.IGNORECASE)
         if (cr[1], cr[3], cr[5]) == (cr[2], cr[4], cr[6]):
             cr = cr[0] + cr[1] + cr[3] + cr[5] + ';'
-            res = re.sub(cr, cro, res, flags=re.IGNORECASE)
-    return res
+            res, count2 = re.sub(cr, cro, res, flags=re.IGNORECASE)
+            count += count
+
+        # Record changes
+        if count > 0:
+            changed[centry] = cro
+
+    return (res, changed)
 
 def add_license(svg, license_data):
     """

--- a/util.py
+++ b/util.py
@@ -3,3 +3,14 @@ def uni_to_hex_hash(uni):
 
 def uni_to_hex_filename(uni):
     return '-'.join(map(lambda x: hex(x)[2:], uni))
+
+def get_color_palettes(emoji, manifest):
+    """Get the source and destination colour palettes for the given emoji."""
+    if 'color' not in emoji:
+        return None
+
+    cmap = manifest.colormaps[emoji['color']]
+    pfrom = manifest.palettes[cmap['src']]
+    pto = manifest.palettes[cmap['dst']]
+
+    return (pfrom, pto)


### PR DESCRIPTION
This pull request adds an export cache system to orxporter, with the goal of 
improving export times.

The cache exists in the form of a directory in which keyed cache files are 
placed. These cache files are the final exports for each format, and their name 
is a key generated from the essential parts of what determines the export: the 
source SVG, and the colour variants that apply to it.

This means that a single SVG changing will only trigger a re-export of the 
emoji that are based on that source; and a change in a palette's colour will 
only require the emoji that use that modified colour to be re-exported.

To improve code reuse, some of the commits in this pull request are not 
strictly related to the cache system, and are refactorings of existing code.

To use this cache one passes the new `-C` flag to `orxport.py`, with an 
argument pointing at a directory (which may or may not exist) to use as a cache.
Without this flag the cache system is not enabled, and orxporter will work as 
if the cache is not present.