### PR TITLE
Bug fix with cache exports

### DIFF
--- a/export_thread.py
+++ b/export_thread.py
@@ -153,6 +153,7 @@ class ExportThread:
                     final_path = dest_paths.format_path(self.path, emoji, f)
                     cache_hit = False
                     if self.cache:
+                        dest_paths.make_dir_structure_for_file(final_path)
                         cache_hit = self.cache.load_from_cache(emoji, f,
                                                                final_path)
                     if not cache_hit:


### PR DESCRIPTION
This fixes a bug by ensuring the output directories are created before the cache files are copied over to the output.

My bad! >_<