### PR TITLE
Improve the cache system performance and make it license-aware

### DIFF
--- a/check.py
+++ b/check.py
@@ -75,8 +75,8 @@ def emoji(m, filtered_emoji, input_path, formats, path, src_size,
 
         if cache:
             # set the cache key in the emoji object for later reference
-            emoji_cache_key = cache.get_cache_key(e, m, emoji_svg)
-            e['cache_key'] = emoji_cache_key
+            emoji_cache_keys = cache.get_cache_keys(e, m, emoji_svg)
+            e['cache_keys'] = emoji_cache_keys
 
             # check if the emoji is in cache
             cache_status = {f: cache.get_cache(e, f) for f in formats}

--- a/check.py
+++ b/check.py
@@ -6,7 +6,7 @@ import svg
 import log
 
 def emoji(m, filtered_emoji, input_path, formats, path, src_size,
-           num_threads, renderer, max_batch, cache, verbose):
+           num_threads, renderer, max_batch, cache, license_enabled, verbose):
     """
     Checks all emoji in a very light validation as well as checking if emoji
     aren't filtered out by user choices.
@@ -29,8 +29,11 @@ def emoji(m, filtered_emoji, input_path, formats, path, src_size,
     """
 
     exporting_emoji = []
-    cached_emoji = []
-    partial_cached_emoji_count = 0
+    cached_emoji = {
+        'exports': [],
+        'licensed_exports': []
+    }
+    cached_emoji_count = 0  # Required to give a correct count without overlap
     skipped_emoji_count = 0
 
     for i, e in enumerate(filtered_emoji):
@@ -74,25 +77,54 @@ def emoji(m, filtered_emoji, input_path, formats, path, src_size,
                                     ))
 
         if cache:
-            # set the cache key in the emoji object for later reference
-            emoji_cache_keys = cache.get_cache_keys(e, m, emoji_svg)
+            # prime the cache keys in the emoji for later
+            emoji_cache_keys = cache.get_cache_keys(e, m, emoji_svg,
+                                                    license_enabled)
             e['cache_keys'] = emoji_cache_keys
 
             # check if the emoji is in cache
-            cache_status = {f: cache.get_cache(e, f) for f in formats}
-            cached_formats = [f for (f, p) in cache_status.items() if p]
-            if len(cached_formats) == len(formats):
-                cached_emoji.append(e)
-            else:
-                if cached_formats:
-                    partial_cached_emoji_count += 1
-                exporting_emoji.append(e)
+            formats_status = {
+                'licensed_export': [],
+                'export': [],
+                'no_cache': []
+            }
+            for f in formats:
+                status = None
+
+                # Attempt to find a licensed export in cache
+                if license_enabled:
+                    status = cache.get_cache(e, f, license_enabled)
+                    if status:
+                        formats_status['licensed_export'].append(f)
+
+                # Attempt to find a non-licensed export in cache
+                if status is None:
+                    status = cache.get_cache(e, f, license_enabled=False)
+                    if status:
+                        formats_status['export'].append(f)
+                    else:
+                        formats_status['no_cache'].append(f)
+
+            # Assign the formats to their cache status and export bins
+            if formats_status['licensed_export']:
+                cached_emoji['licensed_exports'].append((e, formats_status['licensed_export']))
+
+            if formats_status['export']:
+                cached_emoji['exports'].append((e, formats_status['export']))
+
+            if formats_status['export'] or formats_status['licensed_export']:
+                cached_emoji_count += 1
+
+            if formats_status['no_cache']:
+                exporting_emoji.append((e, formats_status['no_cache']))
+
         else:
             # add the emoji to exporting_emoji if it's passed all the tests.
-            exporting_emoji.append(e)
+            # Cache is not enabled; pass all formats to exporting.
+            exporting_emoji.append((e, formats))
 
     return { "exporting_emoji" : exporting_emoji
            , "skipped_emoji_count" : skipped_emoji_count
            , "cached_emoji": cached_emoji
-           , "partial_cached_emoji_count": partial_cached_emoji_count
+           , "cached_emoji_count": cached_emoji_count
            }

--- a/export.py
+++ b/export.py
@@ -10,6 +10,7 @@ from export_thread import ExportThread
 from dest_paths import format_path, make_dir_structure_for_file
 import image_proc
 import log
+from util import get_formats_for_license_type
 
 
 
@@ -106,7 +107,7 @@ def export(m, filtered_emoji, input_path, formats, path, src_size,
 
         for e in itertools.chain(exporting_emoji, cached_emoji):
             for f in formats:
-                if f.split("-")[0] in ["png", "pngc", "avif"]:
+                if f.split("-")[0] in get_formats_for_license_type('exif'):
 
                     try:
                         exif_compatible_images.append(format_path(path, e, f))

--- a/export.py
+++ b/export.py
@@ -28,11 +28,11 @@ def export(m, filtered_emoji, input_path, formats, path, src_size,
     # --------------------------------------------------------------------------
     log.out('Checking emoji...', 36)
     check_result = check.emoji(m, filtered_emoji, input_path, formats, path, src_size,
-               num_threads, renderer, max_batch, cache, verbose)
+               num_threads, renderer, max_batch, cache, license_enabled, verbose)
 
     exporting_emoji = check_result["exporting_emoji"]
     cached_emoji = check_result["cached_emoji"]
-    partial_cached_emoji_count = check_result["partial_cached_emoji_count"]
+    cached_emoji_count = check_result["cached_emoji_count"]
     skipped_emoji_count = check_result["skipped_emoji_count"]
 
 
@@ -48,19 +48,18 @@ def export(m, filtered_emoji, input_path, formats, path, src_size,
         if not verbose:
             log.out(f"            (use the --verbose flag to see what those emoji are and why they are being skipped.)", 34)
 
-    if cached_emoji or partial_cached_emoji_count:
-        log.out(f"->[cache]   {len(cached_emoji)} emoji will be reused from cache.", 34)
+    if cached_emoji_count:
+        log.out(f"->[cache]   {cached_emoji_count} emoji will be reused from cache.", 34)
+        if verbose:
+            log.out(f"->[cache]      {len(cached_emoji['licensed_exports'])} licensed exports.", 34)
+            log.out(f"->[cache]      {len(cached_emoji['exports'])} non-licensed exports.", 34)
 
-    if partial_cached_emoji_count:
-        log.out(f"->[partial] {partial_cached_emoji_count} emoji will be partly reused from cache.", 34)
-        log.out(f"->[export]  {len(exporting_emoji) - partial_cached_emoji_count} emoji will be fully exported.", 34)
-    else:
-        log.out(f"->[export]  {len(exporting_emoji) - partial_cached_emoji_count} emoji will be exported.", 34)
+    log.out(f"->[export]  {len(exporting_emoji)} emoji will be exported.", 34)
 
 
     # If there's no emoji to export, tell the program to quit.
     # --------------------------------------------------------------------------
-    if len(exporting_emoji) == 0 and len(cached_emoji) == 0:
+    if len(exporting_emoji) == 0 and cached_emoji_count == 0:
         raise SystemExit('>∆∆< It looks like you have no emoji to export!')
 
 
@@ -71,25 +70,34 @@ def export(m, filtered_emoji, input_path, formats, path, src_size,
     # declare some specs of this export.
 
     if exporting_emoji:
-        export_step(exporting_emoji, num_threads, m, input_path, formats, path,
+        export_step(exporting_emoji, num_threads, m, input_path, path,
                     renderer, license_enabled, cache)
 
 
 
     # Copy files from cache
     # --------------------------------------------------------------------------
-    if cached_emoji:
-        log.out(f"Copying {len(cached_emoji)} emoji from cache...", 36)
+    if cached_emoji_count > 0:
+        log.out(f"Copying {cached_emoji_count} emoji from cache...", 36)
 
-        bar = log.get_progress_bar(max=len(cached_emoji))
+        bar = log.get_progress_bar(max=cached_emoji_count)
 
         try:
-            for e in cached_emoji:
+            # Copy the exports (without license)
+            for e, fs in cached_emoji['exports']:
                 bar.next()
-                for f in formats:
+                for f in fs:
                     final_path = format_path(path, e, f)
                     make_dir_structure_for_file(final_path)
-                    cache.load_from_cache(e, f, final_path)
+                    cache.load_from_cache(e, f, final_path, False)
+
+            # Copy the licensed exports (populated if license_enabled is True)
+            for e, fs in cached_emoji['licensed_exports']:
+                bar.next()
+                for f in fs:
+                    final_path = format_path(path, e, f)
+                    make_dir_structure_for_file(final_path)
+                    cache.load_from_cache(e, f, final_path, True)
         except (KeyboardInterrupt, SystemExit):
             # Make sure the bar is properly set if oxporter is told to exit
             bar.finish()
@@ -105,12 +113,13 @@ def export(m, filtered_emoji, input_path, formats, path, src_size,
     if ('exif' in m.license) and license_enabled:
         exif_compatible_images = []
 
-        for e in itertools.chain(exporting_emoji, cached_emoji):
-            for f in formats:
+        for e, fs in itertools.chain(exporting_emoji, cached_emoji['exports']):
+            for f in fs:
                 if f.split("-")[0] in get_formats_for_license_type('exif'):
 
                     try:
-                        exif_compatible_images.append(format_path(path, e, f))
+                        final_path = format_path(path, e, f)
+                        exif_compatible_images.append((final_path, e, f))
                     except FilterException:
                         if verbose:
                             log.out(f"- Emoji filtered from metadata: {e['short']}", 34)
@@ -118,13 +127,21 @@ def export(m, filtered_emoji, input_path, formats, path, src_size,
 
         if exif_compatible_images:
             log.out(f'Adding EXIF metadata to all compatible raster files...', 36)
-            image_proc.batch_add_exif_metadata(exif_compatible_images, m.license.get('exif'), max_batch)
+            images_list = (i for i, _, _ in exif_compatible_images)
+            image_proc.batch_add_exif_metadata(images_list, m.license.get('exif'), max_batch)
+
+            # Copy exported emoji to cache
+            if cache:
+                log.out(f"Copying {len(exif_compatible_images)} licensed "
+                        "images to cache...", 36)
+                for final_path, e, f in exif_compatible_images:
+                    if not cache.save_to_cache(e, f, final_path, license_enabled=True):
+                        raise RuntimeError(f"Unable to save '{e['short']}' in "
+                                           f"{f} with license to cache.")
 
 
 
-
-
-def export_step(exporting_emoji, num_threads, m, input_path, formats, path, renderer, license_enabled, cache):
+def export_step(exporting_emoji, num_threads, m, input_path, path, renderer, license_enabled, cache):
     log.out(f"Exporting {len(exporting_emoji)} emoji...", 36)
 
     if num_threads > 1:
@@ -136,7 +153,7 @@ def export_step(exporting_emoji, num_threads, m, input_path, formats, path, rend
         # start a Queue object for emoji export
         emoji_queue = queue.Queue()
 
-        # put the [filtered] emoji (plus the index, cuz enumerate()) into the queue.
+        # put the [filtered] emoji+formats (plus the index, cuz enumerate()) into the queue.
         for entry in enumerate(exporting_emoji):
             emoji_queue.put(entry)
 
@@ -144,8 +161,8 @@ def export_step(exporting_emoji, num_threads, m, input_path, formats, path, rend
         threads = []
         for i in range(num_threads):
             threads.append(ExportThread(emoji_queue, str(i), len(exporting_emoji),
-                                        m, input_path, formats, path, renderer,
-                                        license_enabled, cache))
+                                        m, input_path, path, renderer,
+                                        license_enabled))
 
 
         # keeps checking if the export queue is done.
@@ -192,6 +209,18 @@ def export_step(exporting_emoji, num_threads, m, input_path, formats, path, rend
                 t.join()
 
         raise
+
+    # Copy exported emoji to cache
+    if cache:
+        log.out(f'Copying {len(exporting_emoji)} exported emoji to '
+                'cache...', 36)
+        for emoji, fs in exporting_emoji:
+            for f in fs:
+                export_path = format_path(path, emoji, f)
+                has_license = f in ('svg', 'svgo')
+                if not cache.save_to_cache(emoji, f, export_path, has_license):
+                    raise RuntimeError(f"Unable to save '{emoji['short']}' in "
+                                       f"{f} to cache.")
 
 
     log.out('done!', 32)

--- a/export.py
+++ b/export.py
@@ -112,10 +112,11 @@ def export(m, filtered_emoji, input_path, formats, path, src_size,
     # --------------------------------------------------------------------------
     if ('exif' in m.license) and license_enabled:
         exif_compatible_images = []
+        exif_supported_formats = get_formats_for_license_type('exif')
 
         for e, fs in itertools.chain(exporting_emoji, cached_emoji['exports']):
             for f in fs:
-                if f.split("-")[0] in get_formats_for_license_type('exif'):
+                if f.split("-")[0] in exif_supported_formats:
 
                     try:
                         final_path = format_path(path, e, f)

--- a/export_thread.py
+++ b/export_thread.py
@@ -66,9 +66,11 @@ class ExportThread:
 
         # svg format doesn't involve a resolution so it can go straight to export.
         if f == 'svg':
-            export_task.to_svg(emoji_svg, final_path, self.name, license.get('svg'), self.license_enabled, optimise=False)
+            svg_license = license.get(util.get_license_type_for_format(f))
+            export_task.to_svg(emoji_svg, final_path, self.name, svg_license, self.license_enabled, optimise=False)
         elif f == 'svgo':
-            export_task.to_svg(emoji_svg, final_path, self.name, license.get('svg'), self.license_enabled, optimise=True)
+            svg_license = license.get(util.get_license_type_for_format(f))
+            export_task.to_svg(emoji_svg, final_path, self.name, svg_license, self.license_enabled, optimise=True)
 
         else:
             # any format other than svg is a raster, therefore it needs

--- a/export_thread.py
+++ b/export_thread.py
@@ -16,16 +16,14 @@ class ExportThread:
     A class representing and managing a single thread that executes
     exporting tasks from the export queue.
     """
-    def __init__(self, queue, name, total, m, input_path, formats, path,
-                 renderer, license_enabled, cache):
+    def __init__(self, queue, name, total, m, input_path, path,
+                 renderer, license_enabled):
         self.queue = queue
         self.name = name
         self.total = total
         self.m = m
         self.input_path = input_path
-        self.formats = formats
         self.path = path
-        self.cache = cache
         self.renderer = renderer
         self.license_enabled = license_enabled
         self.err = None
@@ -123,7 +121,7 @@ class ExportThread:
                 # try to get an item from the queue.
                 # break the loop if nothing is left.
                 try:
-                    i, emoji = self.queue.get_nowait()
+                    i, (emoji, formats) = self.queue.get_nowait()
                 except queue.Empty:
                     break
 
@@ -151,18 +149,9 @@ class ExportThread:
                     emoji_svg = svg.translate_color(emoji_svg, pfrom, pto)
 
                 # for each format in the emoji, export it as that
-                for f in self.formats:
-                    final_path = dest_paths.format_path(self.path, emoji, f)
-                    cache_hit = False
-                    if self.cache:
-                        dest_paths.make_dir_structure_for_file(final_path)
-                        cache_hit = self.cache.load_from_cache(emoji, f,
-                                                               final_path)
-                    if not cache_hit:
-                        self.export_emoji(emoji, emoji_svg, f, self.path,
+                for f in formats:
+                    self.export_emoji(emoji, emoji_svg, f, self.path,
                                           self.m.license)
-                        if self.cache:
-                            self.cache.save_to_cache(emoji, f, final_path)
 
                 # tell the progress bar that this task has been completed.
                 log.export_task_count += 1

--- a/util.py
+++ b/util.py
@@ -14,3 +14,21 @@ def get_color_palettes(emoji, manifest):
     pto = manifest.palettes[cmap['dst']]
 
     return (pfrom, pto)
+
+"""Mapping of the license type, keyed by export format."""
+_license_format_map = {
+    'svg': 'svg',
+    'svgo': 'svg',
+    'png': 'exif',
+    'pngc': 'exif',
+    'avif': 'exif',
+}
+
+def get_license_type_for_format(f):
+    """Gets the license type for a given export format, or None if not set."""
+
+    return _license_format_map.get(f.split('-')[0])
+
+def get_formats_for_license_type(t):
+    """Get the export formats for a given license type."""
+    return (f for f, ft in _license_format_map.items() if ft == t)


### PR DESCRIPTION
Make further changes to the cache system to make it aware of exports and exports with license, caching the latter as well. This improves the speed of exporting incrementally, as the EXIF license step doesn't need to run through files that were cached with license.

This pull request includes a number of changes beyond the cache system, that were required for the implementation:

- The check step now keeps track of which formats for each emoji are in cache or need exporting. This required changes in multiple files to use these formats instead of following the global list of formats to export. This change also improves performance, as the cache checking is not necessary anymore.
- The mapping of the export format to license type was centralised in `util.py` with methods to query it; when any new formats of export supporting a license are implemented in the future this mapping becomes a centralised place to make these changes.

This also fixes issue #31, by never caching the SVG and SVGO exports without a license.