### PR TITLE
Make exceptions in the export thread print a traceback

### DIFF
--- a/export.py
+++ b/export.py
@@ -162,7 +162,7 @@ def export_step(exporting_emoji, num_threads, m, input_path, formats, path, rend
                         u.kill()
                         u.join()
 
-                    raise ValueError(f'Thread {t.name} failed: {t.err}')
+                    raise ValueError(f'Thread {t.name} failed: {t.err}') from t.err
 
             if done:
                 break


### PR DESCRIPTION
This is a useful addition to debug problems in the threaded part of
orxporter.