### PR TITLE
Fix major bug with EXIF step not passing all exports to exiftool

### DIFF
--- a/export.py
+++ b/export.py
@@ -127,14 +127,14 @@ def export(m, filtered_emoji, input_path, formats, path, src_size,
                         continue
 
         if exif_compatible_images:
-            log.out(f'Adding EXIF metadata to all compatible raster files...', 36)
+            log.out(f'Adding EXIF metadata to {len(exif_compatible_images)} compatible raster files...', 36)
             images_list = (i for i, _, _ in exif_compatible_images)
             image_proc.batch_add_exif_metadata(images_list, m.license.get('exif'), max_batch)
 
             # Copy exported emoji to cache
             if cache:
                 log.out(f"Copying {len(exif_compatible_images)} licensed "
-                        "images to cache...", 36)
+                        "raster files to cache...", 36)
                 for final_path, e, f in exif_compatible_images:
                     if not cache.save_to_cache(e, f, final_path, license_enabled=True):
                         raise RuntimeError(f"Unable to save '{e['short']}' in "

--- a/util.py
+++ b/util.py
@@ -31,4 +31,4 @@ def get_license_type_for_format(f):
 
 def get_formats_for_license_type(t):
     """Get the export formats for a given license type."""
-    return (f for f, ft in _license_format_map.items() if ft == t)
+    return tuple(f for f, ft in _license_format_map.items() if ft == t)


### PR DESCRIPTION
This was the result of an error introduced in 03cd028. Thanks to @dzuk-mutant for spotting it.

I also added a change to the log line announcing that "EXIF metadata will be added..." so it reports the actual number of raster files that exiftool will process.