### PR TITLE
Fix bug saving SVG files without license to cache as licensed

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -24,6 +24,9 @@ class Cache:
 
     cache_dir = None
 
+    # Formats for which a non-licensed version should never be cached
+    skip_export_cache_formats = set(('svg', 'svgo'))
+
     def __init__(self, cache_dir):
         """
         Initiate an export cache instance. Requires a directory path (which may
@@ -131,6 +134,9 @@ class Cache:
                                "set!".format(emoji['short']))
 
         cache_key = None
+
+        if not license_enabled and f in self.skip_export_cache_formats:
+            return None
 
         if license_enabled:
             if 'licenses' not in emoji['cache_keys']:
@@ -247,3 +253,16 @@ class Cache:
                                "{}".format(emoji['short'], cache_file,
                                            str(exc)))
         return True
+
+    @classmethod
+    def filter_cacheable_formats(cls, fs, license_enabled):
+        """
+        Obtain the formats from `fs` that are cacheable given the status of the
+        license.
+        """
+        cacheable_fs = fs
+
+        if not license_enabled:  # Exports
+            cacheable_fs = tuple(set(fs) - cls.skip_export_cache_formats)
+
+        return cacheable_fs


### PR DESCRIPTION
When using orxporter with the `-l` flag (to disable licenses), a bug
existed when the `Cache.save_to_cache` function was called for the SVG
and SVGO formats, as these were (wrongly) being marked as always having
a license (which is the case when `-l` is not specified), thus making
the function look into a property (`licenses`) of the emoji's cache
keys to determine the cache path, but that property was set to `None`
(usually a `dict` when exporting with licenses).

This was resolved by making non-licensed ("exported") SVG files
explicitly non-cacheable, and properly checking for the license flag
(`license_enabled`) when an SVG/SVGO file is being saved to the cache.

Furthermore simply fixing the call of `save_to_cache` after export to
take into account `license_enabled` for SVG and SVGO exports wouldn't be
sufficient.
This is because orxporter only applies licenses after export for EXIF
licenses, not SVG; any later run of orxporter without `-l` could pick up
the non-licensed SVGs by copying them to the output directory (as it's
done for PNGs and other EXIF-enabled formats), but those files would not
go through a step to add license to them, ending up in the output
directory without any license.
For this reason it is recommended to delete all caches of SVG and SVGO
files.