### PR TITLE
Switch to resvg. Fix inkscape render.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ with that metadata.
 - A [custom declarative language](docs/dzuk/orx.md) for defining your emoji semantics and metadata.
 - Color remapping that automates the production of color-modifiable emoji.
 - The ability to export emoji both as shortcode-named files (ie. 'ice_cream') and unicode codepoint-named files (ie. '1f368')
-- Supports multiple SVG renderers (rendersvg, Inkscape and ImageMagick)
+- Supports multiple SVG renderers (resvg, Inkscape and ImageMagick)
 - Powerful output options including filtering, custom export directory structures and filename modifications.
 - Optional cache system so you can save a lot of time on repeat exports.
 - Multithreaded exports.
@@ -60,11 +60,11 @@ Orxporter depends on other software to produce most image export types.
 ### SVG rasterisers
 One SVG rasteriser is required for Orxporter to export to raster formats (every other format other than `svg` and `svgo`):
 
-| software | purpose |
-| :--    | :-- |
-| [rendersvg](https://github.com/RazrFalcon/resvg/tree/master/tools/rendersvg) | (`-r rendersvg`). **We recommend this one if you don't have complicated SVG elements.** |
-| Inkscape | (`-r inkscape`). Not recommended for macOS users. |
-| ImageMagick  | (`-r imagemagick`). |
+| software | switch | notes
+|----------|--------|-------
+[resvg](https://github.com/RazrFalcon/resvg) | `-r resvg` | Recommended for speed. Available [on AUR, `resvg`](https://aur.archlinux.org/packages/resvg/).
+Inkscape | `-r inkscape` | Not recommended for MacOS users.
+ImageMagick  | `-r imagemagick`
 
 
 ### Other format exporters

--- a/docs/dzuk/howto.md
+++ b/docs/dzuk/howto.md
@@ -56,11 +56,11 @@ Depending on what you have installed on your computer, you can choose:
 
 - `inkscape` (requires inkscape)
 - `imagemagick` (requires ImageMagick)
-- `rendersvg` (requires rendersvg)
+- `resvg` (requires resvg)
 
 *(check the [readme](../../readme.md) for all the information on dependencies)*
 
-Based on our experiences, we highly recommend rendersvg (unless you need fancy SVG support like filters) because it is much faster than the others.
+Based on our experiences, we highly recommend resvg (unless you need fancy SVG support like filters) because it is much faster than the others.
 
 
 ## Cache (`-C`) (optional)

--- a/docs/kiilas/usage.md
+++ b/docs/kiilas/usage.md
@@ -40,7 +40,7 @@ Here are the command line options:
 - **-t NUM** -- number of worker threads (default: **1**)
 - **--force-desc** -- ensure all emoji have description (**desc** property)
 - **-r RENDERER** -- selects rasteriser to use; the following rasterisers are
-  supported: **inkscape**, **rendersvg**, **imagemagick**; **rendersvg** is
+  supported: **inkscape**, **resvg**, **imagemagick**; **resvg** is
   recommended if speed is important; (default: **inkscape**)
 - **-b NUM** -- maximum number of file arguments per exiftool call; larger
   numbers may accelerate metadata insertion but fail if the OS doesn't support

--- a/image_proc.py
+++ b/image_proc.py
@@ -11,11 +11,11 @@ def render_svg(svg_in, png_out, renderer, size):
 
     if renderer == 'inkscape':
         cmd = ['inkscape', os.path.abspath(svg_in),
-               '--export-png=' + os.path.abspath(png_out),
+               '--export-filename=' + os.path.abspath(png_out),
                '-h', str(size), '-w', str(size)]
 
-    elif renderer == 'rendersvg':
-        cmd = ['rendersvg', '-w', str(size), '-h', str(size),
+    elif renderer == 'resvg':
+        cmd = ['resvg', '-w', str(size), '-h', str(size),
                 os.path.abspath(svg_in), os.path.abspath(png_out)]
 
     elif renderer == 'imagemagick':

--- a/orxport.py
+++ b/orxport.py
@@ -15,7 +15,7 @@ from cache import Cache
 
 VERSION = '0.3.0'
 
-RENDERERS = ['inkscape', 'rendersvg', 'imagemagick']
+RENDERERS = ['inkscape', 'resvg', 'imagemagick']
 
 DEF_INPUT = 'in'
 DEF_MANIFEST = 'manifest.orx'
@@ -66,7 +66,7 @@ IMAGE BUILD:
         See the documentation for how this works.
 
 -r      SVG renderer (default: {DEF_RENDERER})
-        - rendersvg
+        - resvg
         - imagemagick
         - inkscape
 


### PR DESCRIPTION
This PR fixes two deprecation issues.

From what I can tell `rendersvg` has been deprecated, (the original link for the dependency was broken, parent project seems to work fine as a substitution), so replace it with `resvg` instead.

Inkscape has also deprecated `--export-png`, so replace it with `--export-filename`.